### PR TITLE
Add animated door intro and conversational interview flow

### DIFF
--- a/src/components/DoorScene.tsx
+++ b/src/components/DoorScene.tsx
@@ -1,5 +1,5 @@
-import { motion, useReducedMotion } from 'framer-motion'
-import { useEffect, useMemo, useState } from 'react'
+import { motion, useReducedMotion, type Variants } from 'framer-motion'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { doorDialogs } from '../data/dialogs'
 import { useT } from '../hooks/useT'
@@ -11,28 +11,146 @@ type DoorSceneProps = {
 export function DoorScene({ onEnter }: DoorSceneProps) {
   const { t, lang } = useT()
   const prefersReducedMotion = useReducedMotion()
-  const [index, setIndex] = useState(0)
+  const [stage, setStage] = useState<'idle' | 'knocking' | 'dialog'>('idle')
+  const [messageIndex, setMessageIndex] = useState(-1)
+  const [typedMessage, setTypedMessage] = useState('')
+  const timers = useRef<number[]>([])
+  const typeInterval = useRef<number | null>(null)
 
-  const dialogs = useMemo(
+  const dialogs = useMemo<string[]>(
     () => doorDialogs.map((item) => (lang === 'es' ? item.es : item.en)),
     [lang],
   )
 
-  useEffect(() => {
-    const interval = window.setInterval(() => {
-      setIndex((prev) => (prev + 1) % dialogs.length)
-    }, 2500)
-    return () => window.clearInterval(interval)
-  }, [dialogs])
+  const introMessage = t<string>('door.intro')
+
+  const sequence = useMemo<string[]>(
+    () => [introMessage, ...dialogs],
+    [dialogs, introMessage],
+  )
+
+  const clearTimers = () => {
+    timers.current.forEach((id) => window.clearTimeout(id))
+    timers.current = []
+    if (typeInterval.current !== null) {
+      window.clearInterval(typeInterval.current)
+      typeInterval.current = null
+    }
+  }
 
   useEffect(() => {
-    setIndex(0)
-  }, [lang])
+    return () => {
+      clearTimers()
+    }
+  }, [])
+
+  useEffect(() => {
+    clearTimers()
+    setStage(prefersReducedMotion ? 'dialog' : 'idle')
+    setMessageIndex(prefersReducedMotion ? 0 : -1)
+    setTypedMessage(prefersReducedMotion ? sequence[0] ?? '' : '')
+
+    if (prefersReducedMotion) {
+      return
+    }
+
+    const idleTimer = window.setTimeout(() => {
+      setStage('knocking')
+    }, 1600)
+    timers.current.push(idleTimer)
+  }, [lang, prefersReducedMotion, sequence])
+
+  useEffect(() => {
+    if (stage !== 'knocking') {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      setStage('dialog')
+      setMessageIndex(0)
+    }, 900)
+
+    timers.current.push(timer)
+  }, [stage])
+
+  useEffect(() => {
+    if (messageIndex < 0 || messageIndex >= sequence.length) {
+      setTypedMessage('')
+      return
+    }
+
+    const message = sequence[messageIndex]
+
+    if (typeof message !== 'string') {
+      setTypedMessage('')
+      return
+    }
+
+    if (prefersReducedMotion) {
+      setTypedMessage(message)
+
+      if (messageIndex < sequence.length - 1) {
+        const timer = window.setTimeout(() => {
+          setMessageIndex((prev) => Math.min(prev + 1, sequence.length - 1))
+        }, 5000)
+        timers.current.push(timer)
+      }
+
+      return
+    }
+
+    if (typeInterval.current !== null) {
+      window.clearInterval(typeInterval.current)
+      typeInterval.current = null
+    }
+
+    setTypedMessage('')
+    let index = 0
+
+    typeInterval.current = window.setInterval(() => {
+      index += 1
+      setTypedMessage(message.slice(0, index))
+
+      if (index >= message.length && typeInterval.current !== null) {
+        window.clearInterval(typeInterval.current)
+        typeInterval.current = null
+
+        if (messageIndex < sequence.length - 1) {
+          const timer = window.setTimeout(() => {
+            setMessageIndex((prev) => Math.min(prev + 1, sequence.length - 1))
+          }, 5000)
+          timers.current.push(timer)
+        }
+      }
+    }, 35)
+
+    return () => {
+      if (typeInterval.current !== null) {
+        window.clearInterval(typeInterval.current)
+        typeInterval.current = null
+      }
+    }
+  }, [messageIndex, prefersReducedMotion, sequence])
+
+  const doorVariants: Variants = {
+    rest: { rotate: 0, x: 0, boxShadow: '0 14px 0 0 rgba(8, 12, 22, 0.65)' },
+    knock: {
+      rotate: [0, -1.2, 1.5, -1, 0.6, 0],
+      x: [0, -4, 4, -3, 2, 0],
+      transition: {
+        duration: 0.7,
+        ease: 'easeInOut',
+        repeat: 2,
+        repeatDelay: 0.1,
+      },
+      boxShadow: '0 18px 0 0 rgba(8, 12, 22, 0.85)',
+    },
+  }
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-10 px-4 py-12 text-center">
       <motion.div
-        className="space-y-6"
+        className="space-y-7"
         initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
         animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
         transition={{ duration: 0.6, ease: 'easeOut' }}
@@ -40,32 +158,64 @@ export function DoorScene({ onEnter }: DoorSceneProps) {
         <motion.div
           role="img"
           aria-label={t('door.intro')}
-          className="mx-auto h-48 w-40 rounded-pixel border-4 border-slate-700 bg-slate-900 shadow-pixel"
-          initial={prefersReducedMotion ? undefined : { scale: 0.8, opacity: 0 }}
-          animate={prefersReducedMotion ? undefined : { scale: 1, opacity: 1 }}
-          transition={{ type: 'spring', stiffness: 120, damping: 12 }}
+          className="relative mx-auto h-52 w-44 rounded-pixel border-4 border-slate-700 bg-slate-900 shadow-pixel"
+          initial={prefersReducedMotion ? undefined : { scale: 0.85, opacity: 0 }}
+          animate={
+            prefersReducedMotion
+              ? undefined
+              : stage === 'knocking'
+                ? 'knock'
+                : 'rest'
+          }
+          variants={prefersReducedMotion ? undefined : doorVariants}
+          transition={{ type: 'spring', stiffness: 130, damping: 14 }}
         >
           <div className="relative h-full w-full overflow-hidden rounded-[18px] border-4 border-slate-800 bg-gradient-to-b from-slate-600 via-slate-700 to-slate-900">
             <div className="absolute inset-x-6 top-5 h-4 rounded-full border-2 border-slate-900 bg-slate-200/80" />
             <div className="absolute inset-x-6 top-12 h-[60%] rounded-lg border-4 border-slate-800 bg-slate-900/70" />
-            <div className="absolute right-6 top-1/2 h-3 w-3 -translate-y-1/2 rounded-full bg-highlight shadow-[0_0_0_2px_rgba(17,17,26,0.7)]" />
+            <motion.div
+              className="absolute inset-0"
+              animate={
+                prefersReducedMotion
+                  ? undefined
+                  : stage === 'knocking'
+                    ? { boxShadow: ['0 0 0 rgba(148, 163, 184, 0)', '0 0 30px rgba(148, 163, 184, 0.25)', '0 0 0 rgba(148, 163, 184, 0)'] }
+                    : { boxShadow: '0 0 0 rgba(148, 163, 184, 0)' }
+              }
+              transition={{ duration: 0.9, ease: 'easeInOut', repeat: stage === 'knocking' ? 2 : 0, repeatDelay: 0.2 }}
+            />
+            <motion.div
+              className="absolute right-6 top-1/2 h-3 w-3 -translate-y-1/2 rounded-full bg-highlight shadow-[0_0_0_2px_rgba(17,17,26,0.7)]"
+              animate={
+                prefersReducedMotion
+                  ? undefined
+                  : stage === 'knocking'
+                    ? { scale: [1, 0.85, 1.1, 1] }
+                    : { scale: 1 }
+              }
+              transition={{ duration: 0.6, ease: 'easeInOut', repeat: stage === 'knocking' ? 2 : 0, repeatDelay: 0.15 }}
+            />
           </div>
         </motion.div>
-        <p className="font-pixel text-lg leading-relaxed text-highlight">{t('door.intro')}</p>
-      </motion.div>
 
-      <div className="max-w-lg space-y-2 rounded-3xl border border-slate-700/70 bg-slate-900/70 p-5 shadow-lg">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{t('door.impatienceLabel')}</p>
-        <motion.p
-          key={dialogs[index]}
+        <motion.div
+          className="mx-auto max-w-xl rounded-3xl border border-slate-700/70 bg-slate-900/70 p-6 shadow-lg"
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 10 }}
-          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, ease: 'easeOut' }}
-          className="font-mono text-sm text-slate-100"
+          animate={stage === 'dialog' ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+          transition={{ duration: 0.5, ease: 'easeOut' }}
+          aria-live="polite"
         >
-          {dialogs[index]}
-        </motion.p>
-      </div>
+          <motion.p
+            key={messageIndex}
+            initial={prefersReducedMotion ? undefined : { opacity: 0, y: 10 }}
+            animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+            className="font-mono text-base text-slate-100"
+          >
+            {typedMessage}
+          </motion.p>
+        </motion.div>
+      </motion.div>
 
       <motion.button
         type="button"

--- a/src/data/dialogs.ts
+++ b/src/data/dialogs.ts
@@ -6,23 +6,18 @@ export type DoorDialog = {
 
 export const doorDialogs: DoorDialog[] = [
   {
-    id: 'patience-1',
-    es: 'Hola... prometo no pisar la alfombra si me dejas pasar.',
-    en: 'Hello... I promise not to step on the rug if you let me in.',
+    id: 'follow-1',
+    es: '¡Holaaa! ¿Hay alguien ahí dentro?',
+    en: 'Hellooo! Is anyone in there?',
   },
   {
-    id: 'patience-2',
-    es: 'Traje galletas digitales. Solo pesan 4kb cada una.',
-    en: 'I brought digital cookies. They only weigh 4kb each.',
+    id: 'follow-2',
+    es: 'Me estoy congelando aquí afuera, ¡por favor!',
+    en: 'I am freezing out here, pretty please!',
   },
   {
-    id: 'patience-3',
-    es: 'Mis píxeles se están congelando aquí fuera...',
-    en: 'My pixels are freezing out here...',
-  },
-  {
-    id: 'patience-4',
-    es: 'Tengo un chiste buenísimo pero solo si abres la puerta.',
-    en: 'I’ve got a killer joke but it requires an open door.',
+    id: 'follow-3',
+    es: 'Si golpeo tres veces es la señal secreta, ¿cierto?',
+    en: 'If I knock three times that is the secret signal, right?',
   },
 ]

--- a/src/i18n/dict.ts
+++ b/src/i18n/dict.ts
@@ -1,11 +1,11 @@
 export type Language = 'es' | 'en'
 
 export type QuestionKey =
-  | 'portfolio'
-  | 'cv'
-  | 'who'
-  | 'stack'
-  | 'joke'
+  | 'introduction'
+  | 'motivation'
+  | 'learning'
+  | 'projects'
+  | 'contact'
 
 type DictSection = {
   common: {
@@ -25,7 +25,6 @@ type DictSection = {
   }
   door: {
     intro: string
-    impatienceLabel: string
     button: string
   }
   interview: {
@@ -33,31 +32,12 @@ type DictSection = {
     subtitle: string
     avatarAlt: string
     selectPrompt: string
-    questions: Record<QuestionKey, string>
-    responses: {
-      who: {
-        heading: string
-        body: string
-      }
-      stack: {
-        heading: string
-        intro: string
-        items: string[]
-      }
-      jokes: {
-        heading: string
-        intro: string
-        items: string[]
-      }
-      cv: {
-        heading: string
-        body: string
-      }
-      portfolio: {
-        heading: string
-        body: string
-        modalCta: string
-      }
+    questions: Record<QuestionKey, { label: string; playerLine: string }>
+    answers: Record<QuestionKey, string>
+    conversation: {
+      youLabel: string
+      characterLabel: string
+      okButton: string
     }
     contact: {
       heading: string
@@ -101,56 +81,51 @@ export const dict: Dict = {
     },
     door: {
       intro: 'Holaaa ¿se puede entrar??!!',
-      impatienceLabel: 'LK está impaciente:',
       button: 'Dejar entrar',
     },
     interview: {
       title: 'Entrevista a LK',
-      subtitle: 'Selecciona una pregunta para obtener una respuesta animada.',
+      subtitle: 'Selecciona una pregunta y charlemos como si estuviéramos frente a la puerta.',
       avatarAlt: 'Avatar pixelado de LK',
       selectPrompt: 'Pulsa un botón para comenzar la conversación.',
       questions: {
-        portfolio: 'Ver portafolio',
-        cv: 'Descargar CV',
-        who: '¿Quién eres tú, bro?',
-        stack: 'Stack y tecnologías',
-        joke: 'Dime un chiste',
+        introduction: {
+          label: 'Hola, preséntate, ¿quién eres?',
+          playerLine: 'Hola, preséntate, ¿quién eres?',
+        },
+        motivation: {
+          label: '¿Por qué te gusta la programación?',
+          playerLine: '¿Por qué te gusta la programación?',
+        },
+        learning: {
+          label: '¿Qué cosas has aprendido últimamente?',
+          playerLine: '¿Qué cosas has aprendido últimamente?',
+        },
+        projects: {
+          label: '¿Cuáles son los proyectos en los que has trabajado?',
+          playerLine: '¿En qué proyectos estuviste trabajando?',
+        },
+        contact: {
+          label: '¿Cómo puedo contactar contigo?',
+          playerLine: '¿Cómo puedo contactar contigo?',
+        },
       },
-      responses: {
-        who: {
-          heading: 'Quién es LK',
-          body:
-            'Soy Luis Ángel Jose Da Silva, desarrollador front-end y creador de experiencias digitales con sabor retro. Me apasiona traducir ideas complejas en interfaces amigables, accesibles y llenas de carácter.',
-        },
-        stack: {
-          heading: 'Stack favorito',
-          intro: 'Estas son las herramientas con las que construyo productos digitales robustos:',
-          items: [
-            'TypeScript + React para interfaces modulares y mantenibles',
-            'Node.js y edge functions para backend ligero',
-            'Tailwind CSS para diseñar a velocidad warp',
-            'Framer Motion para microinteracciones con alma',
-            'Vercel, Netlify y AWS para despliegues sin sustos',
-          ],
-        },
-        jokes: {
-          heading: 'Humor en 8 bits',
-          intro: 'Los píxeles también se ríen. Aquí van algunos chistes malos (pero con cariño):',
-          items: [
-            '¿Por qué el sprite fue a terapia? Porque tenía demasiados frames sin resolver.',
-            'Mi bug favorito es el que se convierte en feature cuando lo presento en 8 bits.',
-            'Pixel art rule #1: si queda raro, agrégale otra sombra y di que es “profundidad”.',
-          ],
-        },
-        cv: {
-          heading: 'Descarga el CV',
-          body: 'Haz clic en el botón para descargar mi CV en PDF y descubrir la versión formal de esta entrevista.',
-        },
-        portfolio: {
-          heading: 'Proyectos destacados',
-          body: 'Explora algunos proyectos seleccionados. Cada tarjeta tiene más detalles dentro.',
-          modalCta: 'Abrir proyecto',
-        },
+      answers: {
+        introduction:
+          'Soy Luis Ángel José Da Silva, pero todos me dicen LK. Soy desarrollador front-end y me encanta darle vida a ideas con estética retro y detallitos que cuentan historias.',
+        motivation:
+          'La programación me gusta porque mezcla lógica con creatividad. Es como armar un rompecabezas donde cada pieza cobra vida cuando todo encaja.',
+        learning:
+          'Últimamente estoy profundizando en animaciones con Framer Motion, accesibilidad aplicada y automatizaciones con IA para acelerar flujos creativos.',
+        projects:
+          'He trabajado en dashboards, experiencias interactivas para eventos y sitios personales con mucho cariño pixel-art. Siempre busco que cada proyecto se sienta único.',
+        contact:
+          'Puedes escribirme por correo a hola@lk.dev o mandarme un mensaje por LinkedIn; contesto rápido si mencionas que viniste por la puerta pixelada.',
+      },
+      conversation: {
+        youLabel: 'Tú',
+        characterLabel: 'LK responde',
+        okButton: 'Okey',
       },
       contact: {
         heading: '¿Quieres hablar?',
@@ -191,56 +166,51 @@ export const dict: Dict = {
     },
     door: {
       intro: 'Heeey! May I come in??!!',
-      impatienceLabel: 'LK is getting impatient:',
       button: 'Let in',
     },
     interview: {
       title: 'Interview LK',
-      subtitle: 'Pick a question to unlock an animated answer.',
+      subtitle: 'Pick a question and let’s role-play this hallway interrogation.',
       avatarAlt: 'LK pixel avatar',
-      selectPrompt: 'Choose any button to kick things off.',
+      selectPrompt: 'Tap a button to start the conversation.',
       questions: {
-        portfolio: 'See portfolio',
-        cv: 'Download CV',
-        who: 'Who are you, bro?',
-        stack: 'Stack & tech',
-        joke: 'Tell me a joke',
+        introduction: {
+          label: 'Hey, introduce yourself. Who are you?',
+          playerLine: 'Hey, introduce yourself. Who are you?',
+        },
+        motivation: {
+          label: 'Why do you enjoy programming?',
+          playerLine: 'Why do you enjoy programming?',
+        },
+        learning: {
+          label: 'What have you learned lately?',
+          playerLine: 'What have you learned lately?',
+        },
+        projects: {
+          label: 'Which projects have you worked on?',
+          playerLine: 'Which projects have you worked on recently?',
+        },
+        contact: {
+          label: 'How can I reach you?',
+          playerLine: 'How can I reach you?',
+        },
       },
-      responses: {
-        who: {
-          heading: 'Who is LK',
-          body:
-            "I'm Luis Ángel Jose Da Silva, a front-end developer crafting digital experiences with a retro heart. I love translating complex ideas into friendly, accessible, character-driven interfaces.",
-        },
-        stack: {
-          heading: 'Favorite stack',
-          intro: 'These are the tools I rely on to build robust digital products:',
-          items: [
-            'TypeScript + React for modular, maintainable interfaces',
-            'Node.js and edge functions for nimble backends',
-            'Tailwind CSS to design at warp speed',
-            'Framer Motion for soulful micro-interactions',
-            'Vercel, Netlify and AWS for stress-free deployments',
-          ],
-        },
-        jokes: {
-          heading: '8-bit humor',
-          intro: 'Pixels laugh too. Here are a few lovingly bad jokes:',
-          items: [
-            "Why did the sprite go to therapy? Too many unresolved frames.",
-            "My favorite bug is the one that becomes a feature once rendered in 8-bit.",
-            "Pixel art rule #1: if it looks weird, add another shadow and call it ‘depth’.",
-          ],
-        },
-        cv: {
-          heading: 'Download the CV',
-          body: 'Hit the button to download my PDF CV and discover the formal version of this chat.',
-        },
-        portfolio: {
-          heading: 'Featured projects',
-          body: 'Explore a handful of curated projects. Each card hides more details inside.',
-          modalCta: 'Open project',
-        },
+      answers: {
+        introduction:
+          'I’m Luis Ángel Jose Da Silva—most people call me LK. I’m a front-end developer obsessed with mixing retro vibes, storytelling and polished interactions.',
+        motivation:
+          'Programming hooks me because it blends creativity with systems thinking. Building an interface feels like composing music with pixels and logic.',
+        learning:
+          'I’ve been diving deeper into Framer Motion, inclusive design practices and little AI helpers that speed up ideation and prototyping.',
+        projects:
+          'Recent work includes interactive dashboards, playful landing pages and personal experiments that celebrate pixel aesthetics. Each project is a new playground.',
+        contact:
+          'Drop me an email at hello@lk.dev or ping me on LinkedIn—mention the mysterious door so I know it’s you.',
+      },
+      conversation: {
+        youLabel: 'You',
+        characterLabel: 'LK replies',
+        okButton: 'Okay',
       },
       contact: {
         heading: 'Want to chat?',


### PR DESCRIPTION
## Summary
- animate the entry door with a staged knock effect and timed message swaps
- redesign the interview view into a conversational exchange with typewriter dialogue and return button
- refresh translations and door follow-up lines to match the new question and answer set

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e139070ae4832c8620ae2610ccb272