### PR TITLE
Adjust interview layout to show single avatar

### DIFF
--- a/src/components/Interview.tsx
+++ b/src/components/Interview.tsx
@@ -157,24 +157,56 @@ export function Interview({ onBack }: InterviewProps) {
       </button>
 
       <div className="flex flex-col items-center gap-8 md:flex-row md:items-start">
-        <motion.div
-          role="img"
-          aria-label={t('interview.avatarAlt')}
-          className="relative h-48 w-48 rounded-pixel border-4 border-slate-700 bg-slate-900 shadow-pixel"
-          initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.9 }}
-          animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
-          transition={{ type: 'spring', stiffness: 120, damping: 14 }}
-        >
-          <div className="absolute inset-[10%] rounded-[22px] border-4 border-slate-800 bg-gradient-to-br from-slate-700 via-slate-800 to-slate-950" />
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
-            <div className="h-12 w-12 rounded-lg border-4 border-slate-900 bg-highlight" />
-            <div className="flex gap-2">
-              <span className="h-3 w-3 rounded-full bg-slate-200" />
-              <span className="h-3 w-3 rounded-full bg-slate-200" />
+        <div className="relative flex flex-col items-center">
+          <motion.div
+            role="img"
+            aria-label={t('interview.avatarAlt')}
+            className="relative h-48 w-48 rounded-pixel border-4 border-slate-700 bg-slate-900 shadow-pixel"
+            initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.9 }}
+            animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
+            transition={{ type: 'spring', stiffness: 120, damping: 14 }}
+          >
+            <div className="absolute inset-[10%] rounded-[22px] border-4 border-slate-800 bg-gradient-to-br from-slate-700 via-slate-800 to-slate-950" />
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
+              <div className="h-12 w-12 rounded-lg border-4 border-slate-900 bg-highlight" />
+              <div className="flex gap-2">
+                <span className="h-3 w-3 rounded-full bg-slate-200" />
+                <span className="h-3 w-3 rounded-full bg-slate-200" />
+              </div>
+              <div className="h-1.5 w-16 rounded-full bg-slate-300" />
             </div>
-            <div className="h-1.5 w-16 rounded-full bg-slate-300" />
-          </div>
-        </motion.div>
+          </motion.div>
+
+          <AnimatePresence mode="popLayout">
+            {answerLine || stage === 'answerTyping' || stage === 'complete' ? (
+              <motion.div
+                key={`answer-${answerLine}`}
+                initial={
+                  prefersReducedMotion
+                    ? undefined
+                    : { opacity: 0, y: 12, scale: 0.98 }
+                }
+                animate={
+                  prefersReducedMotion
+                    ? undefined
+                    : { opacity: 1, y: 0, scale: 1 }
+                }
+                exit={
+                  prefersReducedMotion
+                    ? undefined
+                    : { opacity: 0, y: 12, scale: 0.98 }
+                }
+                transition={{ duration: 0.25, ease: 'easeOut' }}
+                className="mt-4 w-full max-w-xs rounded-2xl border border-slate-700/70 bg-slate-800/90 p-4 text-left text-sm text-slate-100 shadow-inner md:absolute md:left-full md:top-1/2 md:mt-0 md:ml-6 md:w-72 md:-translate-y-1/2 md:transform md:shadow-xl"
+              >
+                <p className="mb-1 text-[11px] uppercase tracking-[0.3em] text-slate-400">
+                  {conversation.characterLabel}
+                </p>
+                <p>{answerLine}</p>
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </div>
         <div className="space-y-3 text-center md:text-left">
           <h1 className="font-pixel text-lg uppercase tracking-[0.5em] text-highlight">
             {t('interview.title')}
@@ -196,63 +228,24 @@ export function Interview({ onBack }: InterviewProps) {
             {!isConversationActive ? (
               <p className="text-center text-sm text-slate-300">{t('interview.selectPrompt')}</p>
             ) : (
-              <div className="flex flex-col items-center gap-8">
-                <motion.div
-                  role="img"
-                  aria-label={conversation.characterLabel}
-                  className="relative h-32 w-32 rounded-pixel border-4 border-slate-700 bg-slate-900 shadow-pixel"
-                  initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.9 }}
-                  animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
-                  transition={{ type: 'spring', stiffness: 140, damping: 12 }}
-                >
-                  <div className="absolute inset-[12%] rounded-[18px] border-4 border-slate-800 bg-gradient-to-br from-slate-700 via-slate-800 to-slate-950" />
-                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
-                    <div className="h-10 w-10 rounded-lg border-4 border-slate-900 bg-highlight" />
-                    <div className="flex gap-2">
-                      <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
-                      <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
-                    </div>
-                    <div className="h-1 w-12 rounded-full bg-slate-300" />
-                  </div>
-                </motion.div>
-
-                <div className="relative flex w-full max-w-3xl flex-col items-center">
-                  <AnimatePresence mode="popLayout">
-                    {playerLine ? (
-                      <motion.div
-                        key={`player-${playerLine}`}
-                        initial={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
-                        animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-                        exit={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
-                        transition={{ duration: 0.3, ease: 'easeOut' }}
-                        className="w-full max-w-md rounded-2xl border border-highlight/60 bg-highlight/15 px-6 py-4 text-center text-sm text-highlight shadow-pixel"
-                      >
-                        <p className="mb-1 text-[11px] uppercase tracking-[0.3em] text-highlight/70">
-                          {conversation.youLabel}
-                        </p>
-                        <p>{playerLine}</p>
-                      </motion.div>
-                    ) : null}
-                  </AnimatePresence>
-
-                  <AnimatePresence mode="popLayout">
-                    {answerLine || stage === 'answerTyping' || stage === 'complete' ? (
-                      <motion.div
-                        key={`answer-${answerLine}`}
-                        initial={prefersReducedMotion ? undefined : { opacity: 0, x: 20 }}
-                        animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
-                        exit={prefersReducedMotion ? undefined : { opacity: 0, x: 20 }}
-                        transition={{ duration: 0.3, ease: 'easeOut' }}
-                        className="mt-6 w-full max-w-sm rounded-2xl border border-slate-700/70 bg-slate-800/80 p-4 text-left text-sm text-slate-100 shadow-inner md:absolute md:left-full md:top-1/2 md:mt-0 md:-translate-y-1/2 md:transform md:shadow-xl"
-                      >
-                        <p className="mb-1 text-[11px] uppercase tracking-[0.3em] text-slate-400">
-                          {conversation.characterLabel}
-                        </p>
-                        <p>{answerLine}</p>
-                      </motion.div>
-                    ) : null}
-                  </AnimatePresence>
-                </div>
+              <div className="flex h-full w-full max-w-3xl flex-col items-center justify-end gap-6">
+                <AnimatePresence mode="popLayout">
+                  {playerLine ? (
+                    <motion.div
+                      key={`player-${playerLine}`}
+                      initial={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
+                      animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                      exit={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
+                      transition={{ duration: 0.3, ease: 'easeOut' }}
+                      className="w-full max-w-md rounded-2xl border border-highlight/60 bg-highlight/15 px-6 py-4 text-center text-sm text-highlight shadow-pixel"
+                    >
+                      <p className="mb-1 text-[11px] uppercase tracking-[0.3em] text-highlight/70">
+                        {conversation.youLabel}
+                      </p>
+                      <p>{playerLine}</p>
+                    </motion.div>
+                  ) : null}
+                </AnimatePresence>
 
                 {showOk ? (
                   <motion.button


### PR DESCRIPTION
## Summary
- keep the interview avatar visible only once at the top of the screen and attach the response bubble to it
- rework the conversation card so the player question stays at the bottom with the confirmation button underneath

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14d13032c832c87c5205ec3b48d5a