### PR TITLE
Remove chat panel container styling

### DIFF
--- a/src/components/Interview.tsx
+++ b/src/components/Interview.tsx
@@ -219,7 +219,6 @@ export function Interview({ onBack }: InterviewProps) {
         <AnimatePresence mode="wait">
           <motion.div
             key={selected ?? 'idle'}
-            className="relative min-h-[260px] rounded-3xl border border-slate-700/70 bg-slate-900/70 p-6 shadow-inner"
             initial={prefersReducedMotion ? undefined : { opacity: 0, y: 15 }}
             animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
             exit={prefersReducedMotion ? undefined : { opacity: 0, y: -10 }}


### PR DESCRIPTION
## Summary
- remove the card-style container styling from the interview chat area so conversation content sits directly on the page background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14f785ce8832c9de627395e27a726