### PR TITLE
Fix interview text animation blur

### DIFF
--- a/src/components/Interview.tsx
+++ b/src/components/Interview.tsx
@@ -180,21 +180,21 @@ export function Interview({ onBack }: InterviewProps) {
           <AnimatePresence mode="popLayout">
             {answerLine || stage === 'answerTyping' || stage === 'complete' ? (
               <motion.div
-                key={`answer-${answerLine}`}
+                key="answer-line"
                 initial={
                   prefersReducedMotion
                     ? undefined
-                    : { opacity: 0, y: 12 }
+                    : { opacity: 0 }
                 }
                 animate={
                   prefersReducedMotion
                     ? undefined
-                    : { opacity: 1, y: 0 }
+                    : { opacity: 1 }
                 }
                 exit={
                   prefersReducedMotion
                     ? undefined
-                    : { opacity: 0, y: 12 }
+                    : { opacity: 0 }
                 }
                 transition={{ duration: 0.25, ease: 'easeOut' }}
                 className="mt-4 w-full max-w-xs rounded-2xl border border-slate-700/70 bg-slate-800/90 p-4 text-left text-sm text-slate-100 shadow-inner md:absolute md:left-full md:top-1/2 md:mt-0 md:ml-6 md:w-72 md:-translate-y-1/2 md:transform md:shadow-xl"
@@ -231,10 +231,10 @@ export function Interview({ onBack }: InterviewProps) {
                 <AnimatePresence mode="popLayout">
                   {playerLine ? (
                     <motion.div
-                      key={`player-${playerLine}`}
-                      initial={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
-                      animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-                      exit={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
+                      key="player-line"
+                      initial={prefersReducedMotion ? undefined : { opacity: 0 }}
+                      animate={prefersReducedMotion ? undefined : { opacity: 1 }}
+                      exit={prefersReducedMotion ? undefined : { opacity: 0 }}
                       transition={{ duration: 0.3, ease: 'easeOut' }}
                       className="w-full max-w-md rounded-2xl border border-highlight/60 bg-highlight/15 px-6 py-4 text-center text-sm text-highlight shadow-pixel"
                     >


### PR DESCRIPTION
## Summary
- avoid remounting interview bubbles on every keystroke so they fade once instead of flickering
- simplify the appear/disappear animation to only fade opacity, preventing blur during typing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1524e00e8832ca4134c35e48ee377