### PR TITLE
Center interview avatar and update copy

### DIFF
--- a/src/components/Interview.tsx
+++ b/src/components/Interview.tsx
@@ -156,12 +156,12 @@ export function Interview({ onBack }: InterviewProps) {
         {t('common.back')}
       </button>
 
-      <div className="flex flex-col items-center gap-8 md:flex-row md:items-start">
+      <div className="flex flex-col items-center gap-6 text-center">
         <div className="relative flex flex-col items-center">
           <motion.div
             role="img"
             aria-label={t('interview.avatarAlt')}
-            className="relative h-48 w-48 rounded-pixel border-4 border-slate-700 bg-slate-900 shadow-pixel"
+            className="relative h-56 w-56 rounded-pixel border-4 border-slate-700 bg-slate-900 shadow-pixel md:h-64 md:w-64"
             initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.9 }}
             animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
             transition={{ type: 'spring', stiffness: 120, damping: 14 }}
@@ -197,7 +197,7 @@ export function Interview({ onBack }: InterviewProps) {
                     : { opacity: 0 }
                 }
                 transition={{ duration: 0.25, ease: 'easeOut' }}
-                className="mt-4 w-full max-w-xs rounded-2xl border border-slate-700/70 bg-slate-800/90 p-4 text-left text-sm text-slate-100 shadow-inner md:absolute md:left-full md:top-1/2 md:mt-0 md:ml-6 md:w-72 md:-translate-y-1/2 md:transform md:shadow-xl"
+                className="mt-4 w-full max-w-xs rounded-2xl border border-slate-700/70 bg-slate-800/90 p-4 text-left text-sm text-slate-100 shadow-inner md:absolute md:left-full md:top-1/2 md:mt-0 md:ml-6 md:w-72 md:-translate-y-1/2 md:transform md:text-left md:shadow-xl"
               >
                 <p className="mb-1 text-[11px] uppercase tracking-[0.3em] text-slate-400">
                   {conversation.characterLabel}
@@ -207,11 +207,11 @@ export function Interview({ onBack }: InterviewProps) {
             ) : null}
           </AnimatePresence>
         </div>
-        <div className="space-y-3 text-center md:text-left">
+        <div className="space-y-3">
           <h1 className="font-pixel text-lg uppercase tracking-[0.5em] text-highlight">
             {t('interview.title')}
           </h1>
-          <p className="max-w-xl text-sm text-slate-300">{t('interview.subtitle')}</p>
+          <p className="mx-auto max-w-xl text-sm text-slate-300">{t('interview.subtitle')}</p>
         </div>
       </div>
 

--- a/src/i18n/dict.ts
+++ b/src/i18n/dict.ts
@@ -84,8 +84,8 @@ export const dict: Dict = {
       button: 'Dejar entrar',
     },
     interview: {
-      title: 'Entrevista a LK',
-      subtitle: 'Selecciona una pregunta y charlemos como si estuviéramos frente a la puerta.',
+      title: 'Entrevista a Luis Da Silva',
+      subtitle: 'Conoce a Luis en profundidad.',
       avatarAlt: 'Avatar pixelado de LK',
       selectPrompt: 'Pulsa un botón para comenzar la conversación.',
       questions: {
@@ -169,8 +169,8 @@ export const dict: Dict = {
       button: 'Let in',
     },
     interview: {
-      title: 'Interview LK',
-      subtitle: 'Pick a question and let’s role-play this hallway interrogation.',
+      title: 'Interview Luis Da Silva',
+      subtitle: 'Get to know Luis in depth.',
       avatarAlt: 'LK pixel avatar',
       selectPrompt: 'Tap a button to start the conversation.',
       questions: {


### PR DESCRIPTION
## Summary
- center the interview avatar and enlarge it to emphasize the character during conversations
- ensure the reply bubble stays beside the avatar while keeping the heading copy centered
- update the Spanish and English interview title and subtitle to reference Luis Da Silva

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15432900c832cacb277a8f3f821bc