### PR TITLE
Fix Resend from-address config and emailSent error reporting

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/node": "^25.2.3",
         "tsx": "^4.19.2",
         "typescript": "5.5.4"
       }
@@ -541,13 +542,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.8.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
-      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.14.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1589,9 +1590,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
-      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/node": "^25.2.3",
     "tsx": "^4.19.2",
     "typescript": "5.5.4"
   }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -27,12 +27,17 @@ export function createApp() {
   app.post('/api/suggestions', async (req, res, next) => {
     try {
       const payload = suggestionSchema.parse(req.body);
-      const emailSent = await sendSuggestionEmail({
+      const { emailSent, error } = await sendSuggestionEmail({
         text: payload.text,
         category: payload.category ? payload.category : null,
         lang: payload.lang,
       });
-      res.status(201).json({ ok: true, emailSent });
+
+      res.status(201).json({
+        ok: true,
+        emailSent,
+        error,
+      });
     } catch (error) {
       next(error);
     }
@@ -41,10 +46,15 @@ export function createApp() {
   app.post('/api/door-entry', async (req, res, next) => {
     try {
       const payload = doorEntrySchema.parse(req.body ?? {});
-      const emailSent = await sendDoorEntryEmail({
+      const { emailSent, error } = await sendDoorEntryEmail({
         lang: payload.lang,
       });
-      res.status(201).json({ ok: true, emailSent });
+
+      res.status(201).json({
+        ok: true,
+        emailSent,
+        error,
+      });
     } catch (error) {
       next(error);
     }

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -5,12 +5,9 @@ config();
 
 const rawEnv = {
   PORT: process.env.PORT ?? '3000',
-  SMTP_HOST: process.env.SMTP_HOST,
-  SMTP_PORT: process.env.SMTP_PORT,
-  SMTP_USER: process.env.SMTP_USER,
-  SMTP_PASS: process.env.SMTP_PASS,
-  SMTP_FROM: process.env.SMTP_FROM,
-  SUGGESTION_EMAIL_TO: process.env.SUGGESTION_EMAIL_TO ?? 'luigidasilv@gmail.com'
+  RESEND_API_KEY: process.env.RESEND_API_KEY,
+  EMAIL_FROM: process.env.EMAIL_FROM,
+  SUGGESTION_EMAIL_TO: process.env.SUGGESTION_EMAIL_TO,
 };
 
 const envSchema = z.object({
@@ -18,16 +15,9 @@ const envSchema = z.object({
     .string()
     .transform((value) => Number.parseInt(value, 10))
     .pipe(z.number().int().positive()),
-  SMTP_HOST: z.string().min(1).optional(),
-  SMTP_PORT: z
-    .string()
-    .transform((value) => Number.parseInt(value, 10))
-    .pipe(z.number().int().positive())
-    .optional(),
-  SMTP_USER: z.string().min(1).optional(),
-  SMTP_PASS: z.string().min(1).optional(),
-  SMTP_FROM: z.string().email().optional(),
-  SUGGESTION_EMAIL_TO: z.string().email().optional()
+  RESEND_API_KEY: z.string().min(1).optional(),
+  EMAIL_FROM: z.string().min(1).optional(),
+  SUGGESTION_EMAIL_TO: z.string().email(),
 });
 
 const parsed = envSchema.safeParse(rawEnv);
@@ -39,10 +29,7 @@ if (!parsed.success) {
 
 export const env = {
   PORT: parsed.data.PORT,
-  SMTP_HOST: parsed.data.SMTP_HOST,
-  SMTP_PORT: parsed.data.SMTP_PORT ?? 587,
-  SMTP_USER: parsed.data.SMTP_USER,
-  SMTP_PASS: parsed.data.SMTP_PASS,
-  SMTP_FROM: parsed.data.SMTP_FROM,
-  SUGGESTION_EMAIL_TO: parsed.data.SUGGESTION_EMAIL_TO ?? 'luigidasilv@gmail.com'
+  RESEND_API_KEY: parsed.data.RESEND_API_KEY,
+  EMAIL_FROM: parsed.data.EMAIL_FROM,
+  SUGGESTION_EMAIL_TO: parsed.data.SUGGESTION_EMAIL_TO,
 };

--- a/backend/src/services/suggestionEmailService.ts
+++ b/backend/src/services/suggestionEmailService.ts
@@ -12,7 +12,12 @@ type DoorEntryEmailPayload = {
   lang?: 'es' | 'en';
 };
 
-const DEFAULT_RECIPIENT = 'luigidasilv@gmail.com';
+type EmailSendResult = {
+  emailSent: boolean;
+  error: string | null;
+};
+
+const FROM = process.env.EMAIL_FROM || 'LuisDaSilvaDev <noreply@luisdasilvadev.com>';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -36,51 +41,67 @@ function buildSuggestionEmailHtml({ text, category, lang }: SuggestionEmailPaylo
   return `<p><strong>${labels.question}:</strong> ${text}</p><p><strong>${labels.category}:</strong> ${categoryValue}</p>`;
 }
 
-export async function sendSuggestionEmail(payload: SuggestionEmailPayload): Promise<boolean> {
+export async function sendSuggestionEmail(payload: SuggestionEmailPayload): Promise<EmailSendResult> {
   if (!isResendConfigured()) {
-    return false;
+    return {
+      emailSent: false,
+      error: 'RESEND_API_KEY is missing.',
+    };
   }
 
-  const fromAddress = env.SMTP_FROM ?? DEFAULT_RECIPIENT;
-  const toAddress = env.SUGGESTION_EMAIL_TO ?? DEFAULT_RECIPIENT;
+  const toAddress = env.SUGGESTION_EMAIL_TO;
   const subject = payload.lang === 'en' ? 'Suggest Question' : 'Pregunta sugerida';
 
   try {
     await resend.emails.send({
-      from: fromAddress,
+      from: FROM,
       to: toAddress,
       subject,
       html: buildSuggestionEmailHtml(payload),
     });
 
-    return true;
+    return {
+      emailSent: true,
+      error: null,
+    };
   } catch (error) {
-    console.error('Failed to send suggestion email with Resend:', error);
-    return false;
+    console.error('Resend email error:', error);
+    return {
+      emailSent: false,
+      error: String((error as { message?: string })?.message || error),
+    };
   }
 }
 
-export async function sendDoorEntryEmail(payload: DoorEntryEmailPayload = {}): Promise<boolean> {
+export async function sendDoorEntryEmail(payload: DoorEntryEmailPayload = {}): Promise<EmailSendResult> {
   if (!isResendConfigured()) {
-    return false;
+    return {
+      emailSent: false,
+      error: 'RESEND_API_KEY is missing.',
+    };
   }
 
-  const fromAddress = env.SMTP_FROM ?? DEFAULT_RECIPIENT;
-  const toAddress = env.SUGGESTION_EMAIL_TO ?? DEFAULT_RECIPIENT;
+  const toAddress = env.SUGGESTION_EMAIL_TO;
   const subject = payload.lang === 'en' ? 'A user has entered' : 'Un usuario ha entrado';
   const body = payload.lang === 'en' ? 'A user has entered' : 'Un usuario ha entrado';
 
   try {
     await resend.emails.send({
-      from: fromAddress,
+      from: FROM,
       to: toAddress,
       subject,
       html: `<p>${body}</p>`,
     });
 
-    return true;
+    return {
+      emailSent: true,
+      error: null,
+    };
   } catch (error) {
-    console.error('Failed to send door entry email with Resend:', error);
-    return false;
+    console.error('Resend email error:', error);
+    return {
+      emailSent: false,
+      error: String((error as { message?: string })?.message || error),
+    };
   }
 }


### PR DESCRIPTION
### Motivation
- Replace legacy SMTP/gmail sender usage with Resend-compatible sender to avoid 403 "Domain not verified" errors by enforcing our verified domain as the `from` address.
- Ensure API responses accurately reflect whether Resend successfully delivered the email instead of always returning success.

### Description
- Updated `backend/src/services/suggestionEmailService.ts` to use `const FROM = process.env.EMAIL_FROM || 'LuisDaSilvaDev <noreply@luisdasilvadev.com>'` and pass `from: FROM` to all `resend.emails.send(...)` calls.
- Ensured recipient stays `to: env.SUGGESTION_EMAIL_TO` for both suggestion and door-entry emails and removed any reliance on `SMTP_*` env vars or `luigidasilv@gmail.com` as the `from` address.
- Changed email send functions to return a structured result `{ emailSent: boolean, error: string | null }` and implemented `try/catch` so `emailSent` is `true` only on successful `await resend.emails.send(...)` and `false` on error, logging `Resend email error:` on failure.
- Updated `backend/src/app.ts` endpoints `POST /api/suggestions` and `POST /api/door-entry` to forward the service result and return `{ ok: true, emailSent, error }` in the response.
- Simplified `backend/src/env.ts` to only parse `RESEND_API_KEY`, `EMAIL_FROM`, `SUGGESTION_EMAIL_TO` (and `PORT`) and removed SMTP-related env parsing.
- Added `@types/node` to `devDependencies` in `backend/package.json` so the TypeScript build runs cleanly in the environment.

### Testing
- Ran `npm run build` in `backend/` to validate TypeScript compilation and dependency changes, and the build succeeded.
- Type-checking and local compilation validated the modified modules and updated env schema without runtime tests; no automated integration tests were present or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949b21dfcc832c9edd57282b3a4596)