### PR TITLE
Actualizar textos de correos en español

### DIFF
--- a/backend/src/services/suggestionEmailService.ts
+++ b/backend/src/services/suggestionEmailService.ts
@@ -31,14 +31,13 @@ function isResendConfigured() {
 }
 
 function buildSuggestionEmailHtml({ text, category, lang }: SuggestionEmailPayload) {
-  const labels =
-    lang === 'en'
-      ? { question: 'Question', category: 'Category' }
-      : { question: 'Pregunta', category: 'Categoría' };
-
   const categoryValue = category?.trim() ? category.trim() : lang === 'en' ? 'Unspecified' : 'Sin categoría';
 
-  return `<p><strong>${labels.question}:</strong> ${text}</p><p><strong>${labels.category}:</strong> ${categoryValue}</p>`;
+  if (lang !== 'en') {
+    return `<p>Tienes la siguiente Sugerencia de pregunta:</p><p>Pregunta: ${text}</p><p>Categoria: ${categoryValue}</p>`;
+  }
+
+  return `<p><strong>Question:</strong> ${text}</p><p><strong>Category:</strong> ${categoryValue}</p>`;
 }
 
 export async function sendSuggestionEmail(payload: SuggestionEmailPayload): Promise<EmailSendResult> {
@@ -50,7 +49,7 @@ export async function sendSuggestionEmail(payload: SuggestionEmailPayload): Prom
   }
 
   const toAddress = env.SUGGESTION_EMAIL_TO;
-  const subject = payload.lang === 'en' ? 'Suggest Question' : 'Pregunta sugerida';
+  const subject = payload.lang === 'en' ? 'Suggest Question' : 'Te han sugerido una Pregunta';
 
   try {
     await resend.emails.send({
@@ -82,8 +81,8 @@ export async function sendDoorEntryEmail(payload: DoorEntryEmailPayload = {}): P
   }
 
   const toAddress = env.SUGGESTION_EMAIL_TO;
-  const subject = payload.lang === 'en' ? 'A user has entered' : 'Un usuario ha entrado';
-  const body = payload.lang === 'en' ? 'A user has entered' : 'Un usuario ha entrado';
+  const subject = payload.lang === 'en' ? 'A user has entered' : 'Has entrado a una entrevista!';
+  const body = payload.lang === 'en' ? 'A user has entered' : 'Un usuario te ha dejado pasar para la entrevista!';
 
   try {
     await resend.emails.send({


### PR DESCRIPTION
### Motivation
- Hacer más amigables y específicos los textos de los correos enviados por el backend para notificaciones de entrada y sugerencias.
- Ajustar el asunto y el contenido en español para que sigan el formato solicitado (texto claro y con etiquetas de `Pregunta` y `Categoria`).
- Mantener la versión en inglés sin cambios funcionales excepto el formato HTML de la sugerencia.

### Description
- Se actualizó la función `buildSuggestionEmailHtml` en `backend/src/services/suggestionEmailService.ts` para devolver en español el cuerpo con el formato: `Tienes la siguiente Sugerencia de pregunta`, `Pregunta: ...`, `Categoria: ...` y mantener el HTML en inglés con `Question` y `Category`.
- Se cambió el asunto del correo de sugerencia en español a `Te han sugerido una Pregunta` en `sendSuggestionEmail`.
- Se cambió el asunto y el cuerpo del correo de entrada en español a `Has entrado a una entrevista!` y `Un usuario te ha dejado pasar para la entrevista!` respectivamente en `sendDoorEntryEmail`.

### Testing
- Se ejecutó `npm install` en `backend` para preparar dependencias y la instalación se completó correctamente.
- Se ejecutó `npm run build` en `backend` y la compilación TypeScript finalizó correctamente después de instalar dependencias.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949e516f78832cbdbba41b1ffc0114)